### PR TITLE
Issue/31

### DIFF
--- a/Cedita.Payroll.Tests/StatutoryMaternityPayTests2018.cs
+++ b/Cedita.Payroll.Tests/StatutoryMaternityPayTests2018.cs
@@ -99,5 +99,49 @@ namespace Cedita.Payroll.Tests
             Assert.IsTrue(statutoryPayments.All(x => Math.Round(x.Cost, 2, MidpointRounding.AwayFromZero) == 16.07m));
 
         }
+
+        [TestCategory("Statutory Maternity Pay Tests"), TestMethod]
+        public void SmpAverageEarningsCalculationTest()
+        {
+            // Week long sick note, this is the first sick note they have claimed
+            var maternityPayAssessment = (new MockMaternityPayAssessment())
+                .WithBirthDate(new DateTime(2020, 01, 07))
+                .WithDueDate(new DateTime(2020, 01, 07))
+                .WithStartDate(new DateTime(2020, 01, 07))
+                .WithNextPaymentDate(new DateTime(2020, 01, 10))
+                .WithEmploymentContract(true)
+                .WithEarningsInPeriod(2000m)
+                .WithPaymentsInPeriod(8)
+                .WithPaymentFrequency(PayPeriods.Weekly)
+                .GetAssessment();
+
+            var statutoryCalculation = GetSmpCalculation(2019, maternityPayAssessment);
+            var statutoryPayments = statutoryCalculation.Payments;
+
+            var firstFullWeekPaymentAverageEarnings = statutoryPayments.Skip(1).First();
+            Assert.AreEqual(225m, Math.Round(firstFullWeekPaymentAverageEarnings.Total, 2, MidpointRounding.AwayFromZero), "Average Earnings Total");
+        }
+
+        [TestCategory("Statutory Maternity Pay Tests"), TestMethod]
+        public void SmpBelowMinimumEarningsCalculationTest()
+        {
+            // Week long sick note, this is the first sick note they have claimed
+            var maternityPayAssessment = (new MockMaternityPayAssessment())
+                .WithBirthDate(new DateTime(2020, 01, 07))
+                .WithDueDate(new DateTime(2020, 01, 07))
+                .WithStartDate(new DateTime(2020, 01, 07))
+                .WithNextPaymentDate(new DateTime(2020, 01, 10))
+                .WithEmploymentContract(true)
+                .WithEarningsInPeriod(500m)
+                .WithPaymentsInPeriod(8)
+                .WithPaymentFrequency(PayPeriods.Weekly)
+                .GetAssessment();
+
+            var statutoryCalculation = GetSmpCalculation(2019, maternityPayAssessment);
+            var statutoryPayments = statutoryCalculation.Payments;
+
+            // Ensure the figure below statutory minimum is used (90% of average earnings)
+            Assert.AreEqual(2193.77m, Math.Round(statutoryPayments.Sum(x => x.Total), 2, MidpointRounding.AwayFromZero), "Below Statutory Earnings Total");
+        }
     }
 }

--- a/Cedita.Payroll.Tests/StatutoryMaternityPayTests2018.cs
+++ b/Cedita.Payroll.Tests/StatutoryMaternityPayTests2018.cs
@@ -143,5 +143,30 @@ namespace Cedita.Payroll.Tests
             // Ensure the figure below statutory minimum is used (90% of average earnings)
             Assert.AreEqual(2193.77m, Math.Round(statutoryPayments.Sum(x => x.Total), 2, MidpointRounding.AwayFromZero), "Below Statutory Earnings Total");
         }
+
+        [TestCategory("Statutory Maternity Pay Tests"), TestMethod]
+        public void Calculate42CorrectPaymentsAtNintyPercent()
+        {
+            // Week long sick note, this is the first sick note they have claimed
+            var maternityPayAssessment = (new MockMaternityPayAssessment())
+                .WithBirthDate(new DateTime(2020, 07, 01))
+                .WithDueDate(new DateTime(2020, 07, 01))
+                .WithStartDate(new DateTime(2020, 04, 12))
+                .WithNextPaymentDate(new DateTime(2020, 04, 24))
+                .WithEmploymentContract(true)
+                .WithEarningsInPeriod(2000m)
+                .WithPaymentsInPeriod(8)
+                .WithPaymentFrequency(PayPeriods.Weekly)
+                .GetAssessment();
+
+            var statutoryCalculation = GetSmpCalculation(2019, maternityPayAssessment);
+            //The first 6 payments should be calculated at 90% of their weekly rate. E.g. £250 / 0.9 = £225. £225 / 7 = £32.14 (the average day rate).
+            var statutoryPayments = statutoryCalculation.Payments.Take(6);
+
+            var averageCost = Math.Round(statutoryPayments.Average(x => x.Cost), 2, MidpointRounding.AwayFromZero);
+
+            Assert.AreEqual(32.14m, averageCost, "Below Statutory Earnings Total");
+
+        }
     }
 }

--- a/Cedita.Payroll.Tests/StatutoryPaternityPayTests2018.cs
+++ b/Cedita.Payroll.Tests/StatutoryPaternityPayTests2018.cs
@@ -64,5 +64,34 @@ namespace Cedita.Payroll.Tests
             Assert.AreEqual(new DateTime(2019, 05, 24), finalPayment.PaymentDate, "Unexpected payment date for third payment");
         }
 
+        [TestCategory("Statutory Paternity Pay Tests"), TestMethod]
+        public void ValidSppClaimDaysPerWeek()
+        {
+            // Week long sick note, this is the first sick note they have claimed
+            var paternityPayAssessment = (new MockPaternityPayAssessment())
+                .WithDueDate(new DateTime(2020, 01, 31))
+                .WithStartDate(new DateTime(2020, 01, 31))
+                .WithNextPaymentDate(new DateTime(2020, 01, 31))
+                .WithTotalClaimDays(13)
+                .WithEarningsInPeriod(2000m)
+                .WithPaymentsInPeriod(8)
+                .WithIsResponsibleFatherAnswer(true)
+                .WithEmployeeWorkedInPeriodAnswer(true)
+                .WithEmployeeHasContractAnswer(true)
+                .WithEmployeeOnPayrollAnswer(true)
+                .WithEmployedAtBirthAnswer(true)
+                .WithPaymentFrequency(PayPeriods.Weekly)
+                .GetAssessment();
+
+            var assessmentCalculation = GetSppCalculation(2019, paternityPayAssessment);
+            var statutoryPayments = assessmentCalculation.Payments;
+
+            Assert.AreEqual(14, statutoryPayments.Sum(m => m.Qty), "Unexpected total days paternity pay");
+            Assert.AreEqual(297.36m, statutoryPayments.Sum(m => m.Qty * m.Cost), "Unexpected amount of total paternity pay");
+
+            // Ensure first payment is a single day
+            var firstPayment = statutoryPayments.First();
+            Assert.AreEqual(1m, firstPayment.Qty, "Unexpected qty of paternity pay");
+        }
     }
 }

--- a/Cedita.Payroll/Calculation/StatutoryPayments/SmpCalculationEngine.cs
+++ b/Cedita.Payroll/Calculation/StatutoryPayments/SmpCalculationEngine.cs
@@ -60,7 +60,7 @@ namespace Cedita.Payroll.Calculation.StatutoryPayments
                 totalDaysClaimed++;
 
                 // First 6 weeks we claim the average rate
-                if (totalDaysClaimed <= (7 * 6))
+                if (totalDaysClaimed <= 43)
                 {
                     statPayment.Cost = belowAverageEarningsCost;
                     statPayment.IsStatutoryMinimumRate = false;
@@ -100,6 +100,7 @@ namespace Cedita.Payroll.Calculation.StatutoryPayments
 
                 // We do want to pay this date
                 statPayment.Qty += 1m;
+
             }
 
             // Add the last period

--- a/Cedita.Payroll/Calculation/StatutoryPayments/SmpCalculationEngine.cs
+++ b/Cedita.Payroll/Calculation/StatutoryPayments/SmpCalculationEngine.cs
@@ -42,7 +42,7 @@ namespace Cedita.Payroll.Calculation.StatutoryPayments
             var scheduledPayments = new List<StatutoryPayment>();
 
             var datesInRange = model.GetQualifyingDatesInRange();
-            var nextPaymentDate = model.UpcomingPaymentDateForPeriod;
+            var nextPaymentDate = (model.UpcomingPaymentDate.Value >= datesInRange.First() ? model.UpcomingPaymentDate.Value : model.UpcomingPaymentDate.Value.AddDays(7));
 
             var belowAverageEarningsCost = (model.AverageWeeklyEarnings * 0.9m) / 7;
 
@@ -79,6 +79,7 @@ namespace Cedita.Payroll.Calculation.StatutoryPayments
                         PaymentDate = nextPaymentDate.AddDays(7),
                         Cost = Math.Min(belowAverageEarningsCost, taxYearConfigurationData.StatutoryMaternityPayDayRate),
                         Qty = 0m,
+                        IsStatutoryMinimumRate = (belowAverageEarningsCost > taxYearConfigurationData.StatutoryMaternityPayDayRate)
                     };
                 }
 
@@ -93,6 +94,7 @@ namespace Cedita.Payroll.Calculation.StatutoryPayments
                         PaymentDate = statPayment.PaymentDate,
                         Cost = Math.Min(belowAverageEarningsCost, taxYearConfigurationData.StatutoryMaternityPayDayRate),
                         Qty = 0m,
+                        IsStatutoryMinimumRate = (belowAverageEarningsCost > taxYearConfigurationData.StatutoryMaternityPayDayRate)
                     };
                 }
 

--- a/Cedita.Payroll/Calculation/StatutoryPayments/SppCalculationEngine.cs
+++ b/Cedita.Payroll/Calculation/StatutoryPayments/SppCalculationEngine.cs
@@ -40,7 +40,7 @@ namespace Cedita.Payroll.Calculation.StatutoryPayments
             assessmentCalculation.IsEligible = model.IsEligible;
             var scheduledPayments = new List<StatutoryPayment>();
             var datesInRange = model.GetQualifyingDatesInRange();
-            var nextPaymentDate = (model.UpcomingPaymentDate.Value > datesInRange.First() ? model.UpcomingPaymentDate.Value : model.UpcomingPaymentDate.Value.AddDays(7));
+            var nextPaymentDate = (model.UpcomingPaymentDate.Value >= datesInRange.First() ? model.UpcomingPaymentDate.Value : model.UpcomingPaymentDate.Value.AddDays(7));
 
             var statPayment = new StatutoryPayment
             {

--- a/Cedita.Payroll/Calculation/StatutoryPayments/SspCalculationEngine.cs
+++ b/Cedita.Payroll/Calculation/StatutoryPayments/SspCalculationEngine.cs
@@ -37,7 +37,7 @@ namespace Cedita.Payroll.Calculation.StatutoryPayments
             var scheduledPayments = new List<StatutoryPayment>();
 
             var datesInRange = GetSickDays(model, !model.ApplyWaitingDays);
-            var nextPaymentDate = model.UpcomingPaymentDateForPeriod;
+            var nextPaymentDate = (model.UpcomingPaymentDate.Value >= datesInRange.First() ? model.UpcomingPaymentDate.Value : model.UpcomingPaymentDate.Value.AddDays(7));
             var maxSickDays = Math.Max(140 - model.PreviousSickDaysTotal, 0);
             var totalDaysClaimed = 0;
 

--- a/Cedita.Payroll/Cedita.Payroll.csproj
+++ b/Cedita.Payroll/Cedita.Payroll.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>2.2.8</Version>
+    <Version>2.2.9</Version>
     <Authors>Cedita</Authors>
     <Company>Cedita Ltd</Company>
     <Description>.NET Standard implementation of the United Kingdom's HMRC UK Tax legislation.</Description>

--- a/Cedita.Payroll/Models/Statutory/Assessments/MaternityPayAssessment.cs
+++ b/Cedita.Payroll/Models/Statutory/Assessments/MaternityPayAssessment.cs
@@ -29,9 +29,9 @@ namespace Cedita.Payroll.Models.Statutory.Assessments
         {
             get
             {
-                if (!DueDate.HasValue)
+                if (!DueDate.HasValue && !StartDate.HasValue) // Start Date First - and if not known, default to due date
                     return (DateTime?)null;
-                return DueDate?.AddDays(-28);
+                return (StartDate ?? DueDate)?.AddDays(-28);
             }
         }
 

--- a/Cedita.Payroll/Models/Statutory/Assessments/PaternityPayAssessment.cs
+++ b/Cedita.Payroll/Models/Statutory/Assessments/PaternityPayAssessment.cs
@@ -98,7 +98,7 @@ namespace Cedita.Payroll.Models.Statutory.Assessments
             {
                 if (!StartDate.HasValue && !DueDate.HasValue)
                     return (DateTime?)null;
-                return (StartDate ?? DueDate)?.GetNextWeekday(DayOfWeek.Saturday).AddDays(-(7 * 15));
+                return (DueDate ?? StartDate)?.GetNextWeekday(DayOfWeek.Saturday).AddDays(-(7 * 15));
             }
         }
 

--- a/Cedita.Payroll/Models/Statutory/StatutoryPayment.cs
+++ b/Cedita.Payroll/Models/Statutory/StatutoryPayment.cs
@@ -18,6 +18,6 @@ namespace Cedita.Payroll.Models.Statutory
         /// The HMRC Spec states that this should be truncated to 5 decimal places, then always rounded up to the nearest penny. Unless
         /// of course it's the statutory rate that is a flat £145.18 a week / £20.74 a day
         /// </summary>
-        public decimal Total => (IsStatutoryMinimumRate ? (Qty * Cost) : TaxMath.UpRound(TaxMath.Truncate(Qty * Cost, 5), 2));
+        public decimal Total => (IsStatutoryMinimumRate ? (Qty * Cost) : TaxMath.UpRound(TaxMath.Truncate(Cost, 5) * Qty, 2));
     }
 }


### PR DESCRIPTION
- [x] RE SMP - The first 6 payments should be calculated at 90% of the workers weekly pay and then the remaining 33 amounts at statutory. Once we have calculated the first 6 weeks then any more payments after that are calculated at statutory rate. We need to amend this so the first 42 individual payments are calculated at the 90% day rate.